### PR TITLE
Fixed faulty error messages for 'lte' and 'gte' validators.

### DIFF
--- a/gladiator/validators.py
+++ b/gladiator/validators.py
@@ -164,5 +164,5 @@ lt = partial(_value, name='lt', attrib='__lt__', err_msg='{selector} is not less
 gt = partial(_value, name='gt', attrib='__gt__', err_msg='{selector} is not greater then {value}.')
 eq = partial(_value, name='eq', attrib='__eq__', err_msg='{selector} is not equal to {value}.')
 ne = partial(_value, name='ne', attrib='__ne__', err_msg='{selector} is equal to {value}.')
-lte = partial(_value, name='lte', attrib='__le__', err_msg='{selector is not less or equal to {value}.')
-gte = partial(_value, name='gte', attrib='__ge__', err_msg='{selector is not greater or equal to {value}.')
+lte = partial(_value, name='lte', attrib='__le__', err_msg='{selector} is not less or equal to {value}.')
+gte = partial(_value, name='gte', attrib='__ge__', err_msg='{selector} is not greater or equal to {value}.')

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -1,0 +1,69 @@
+import gladiator as gl
+
+
+#
+# Comparison validators
+#
+
+comparison_validators_test_data = [
+    {
+        'validator': gl.lt(5),
+        'valid': [1, 2, 3, 4],
+        'invalid': [5, 6, 7, 8, 9, 10],
+        'error': 'is not less then'
+    },
+    {
+        'validator': gl.gt(5),
+        'valid': [6, 7, 8, 9, 10],
+        'invalid': [1, 2, 3, 4, 5],
+        'error': 'is not greater then'
+    },
+    {
+        'validator': gl.eq(5),
+        'valid': [5],
+        'invalid': [1, 2, 3, 4, 6, 7, 8, 9, 10],
+        'error': 'is not equal to'
+    },
+    {
+        'validator': gl.ne(5),
+        'valid': [1, 2, 3, 4, 6, 7, 8, 9, 10],
+        'invalid': [5],
+        'error': 'is equal to'
+    },
+    {
+        'validator': gl.lte(5),
+        'valid': [1, 2, 3, 4, 5],
+        'invalid': [6, 7, 8, 9, 10],
+        'error': 'is not less or equal to'
+    },
+    {
+        'validator': gl.gte(5),
+        'valid': [5, 6, 7, 8, 9, 10],
+        'invalid': [1, 2, 3, 4],
+        'error': 'is not greater or equal to'
+    }
+]
+
+
+def _yield_test_data(value_type):
+    for validator_data in comparison_validators_test_data:
+        validator = validator_data['validator']
+        error = validator_data['error']
+        for value in validator_data[value_type]:
+            yield \
+                (('test_field', validator),), \
+                {'test_field': value}, \
+                error
+
+
+def test_comparison_operators_with_valid_values():
+    for validation_rules, test_object, _ in _yield_test_data('valid'):
+        result = gl.validate(validation_rules, test_object)
+        assert result.success is True
+
+
+def test_comparison_operators_with_invalid_values():
+    for validation_rules, test_object, error in _yield_test_data('invalid'):
+        result = gl.validate(validation_rules, test_object)
+        assert result.success is False
+        assert error in result.errors[0][1]


### PR DESCRIPTION
Incomplete '**{selector**' tokens caused string formatting exception while trying to get the list of validation errors via '**errors**' property:

```
lte = partial(_value, name='lte', attrib='__le__', err_msg='{selector is not less or equal to {value}.')
gte = partial(_value, name='gte', attrib='__ge__', err_msg='{selector is not greater or equal to {value}.')
```

```
    def _error_msg(self):
        _ctx = {
            'selector': selector_as_string(self.selector),
        }
        gettext = self.ctx['trans'].gettext
        _ctx.update(self.ctx)
        _ctx.update(self.msg_ctx)
>       return str(gettext(self.msg)).format(**_ctx)

E       ValueError: unexpected '{' in field name
```
